### PR TITLE
Optimized huawei_vrp launch.py

### DIFF
--- a/huawei_vrp/docker/launch.py
+++ b/huawei_vrp/docker/launch.py
@@ -42,6 +42,8 @@ class VRP_vm(vrnetlab.VM):
     def __init__(self, username, password, hostname, conn_mode):
         disk_image = None
         self.vm_type = "UNKNOWN"
+        self.vm_version = "UNKNOWN"
+
         for e in sorted(os.listdir("/")):
             if not disk_image and re.search(".qcow2$", e):
                 disk_image = "/" + e
@@ -50,14 +52,36 @@ class VRP_vm(vrnetlab.VM):
                 if "huawei_ce12800" in e:
                     self.vm_type = "CE12800"
 
+                # try to detect VRP version from filename (qcow images should contain strings like V800R011,V800R022,V800R023)
+                m = re.search(r"(V\d+R\d+)", e)
+                if m:
+                    self.vm_version = m.group(1)
+
+        # default values which will be used when there is no match
+        ram = 4096
+        smp = "4"
+
+        # override depending on version
+        if self.vm_version == "V800R022":
+            ram = 8192
+            smp = "8"
+        elif self.vm_version in ["V800R023", "V800R011"]:
+            ram = 4096
+            smp = "2"
+
         super(VRP_vm, self).__init__(
             username,
             password,
             disk_image=disk_image,
-            ram=2048,
-            smp="2",
+            ram=ram,
+            smp=smp,
             driveif="virtio",
         )
+
+        # Add SATA controller and disk attachment (this is probably not needed but doesn't hurt either)
+        self.qemu_args.extend([
+            "-machine", "pc-q35-6.2",  # Use q35 machine type for better SATA support
+        ])
 
         self.hostname = hostname
         self.conn_mode = conn_mode
@@ -68,42 +92,75 @@ class VRP_vm(vrnetlab.VM):
         """This function should be called periodically to do work."""
 
         if self.spins > 300:
-            # too many spins with no result ->  give up
+            # too many spins with no result -> give up and restart
             self.stop()
             self.start()
             return
 
+        # First check for prompt
         (ridx, match, res) = self.tn.expect([b"<HUAWEI>"], 1)
 
-        if match and ridx == 0:  # got a match!
-            # run main config!
+        # Read any additional available output immediately
+        try:
+            extra_output = self.tn.read_very_eager()
+        except EOFError:
+            extra_output = b""
+
+        # Combine the two (so we don’t miss anything)
+        full_output = b"".join([res or b"", extra_output or b""])
+
+        # Print/log each line received
+        if full_output:
+            try:
+                decoded_output = full_output.decode(errors="ignore")
+            except UnicodeDecodeError:
+                decoded_output = str(full_output)
+
+            for line in decoded_output.splitlines():
+                if line.strip():  # skip empty lines
+                    self.logger.info(f"DEVICE: {line}")
+            self.spins = 0  # reset spin counter if we saw anything
+
+        # If prompt matched do config
+        if match and ridx == 0:
+            
+            # fetch VRP version first
+            self.logger.info("Fetching VRP version...")
+            self.tn.write(b"display version\n")
+            time.sleep(3)
+            output = self.tn.read_until(b"<", timeout=3).decode(errors="ignore")
+
+            # extract VRP version
+            import re
+            # Look for something like V800R011C00 (ignore SPC part)
+            m = re.search(r"(V\d+R\d+C\d+)", output)
+            if m:
+                self.vm_version = m.group(1)   # only the first part
+                self.logger.info(f"Detected VRP version: {self.vm_version}")
+            else:
+                self.vm_version = "UNKNOWN"
+                self.logger.warning("Could not detect VRP version!")
+
+            # call the startup and bootstrap methods
             self.logger.info("Running bootstrap_config()")
             self.startup_config()
             self.bootstrap_config()
             time.sleep(1)
-            # close telnet connection
             self.tn.close()
-            # startup time?
             startup_time = datetime.datetime.now() - self.start_time
-            self.logger.info("Startup complete in: %s" % startup_time)
-            # mark as running
+            self.logger.info(f"Startup complete in: {startup_time}")
             self.running = True
             return
 
         time.sleep(5)
-
-        # no match, if we saw some output from the router it's probably
-        # booting, so let's give it some more time
-        if res != b"":
-            self.logger.trace("OUTPUT: %s" % res.decode())
-            # reset spins if we saw some output
-            self.spins = 0
-
         self.spins += 1
 
         return
 
     def bootstrap_mgmt_interface(self):
+        # wait for system to become ready for configuration
+        self.logger.info("bootstrap_mgmt_interface - Sleeping for another 60s to wait for the system to become ready...()")
+        time.sleep(60)
         self.wait_write(cmd="mmi-mode enable", wait=None)
         self.wait_write(cmd="system-view", wait=">")
         self.wait_write(cmd="ip vpn-instance __MGMT_VPN__", wait="]")
@@ -133,6 +190,24 @@ class VRP_vm(vrnetlab.VM):
 
     def bootstrap_config(self):
         """Do the actual bootstrap config"""
+
+    # Example: conditional config
+        if getattr(self, "vm_version", None) == "V800R023C00":
+            self.logger.info("Applying config for VRP version V800R023C00")
+            # run R23 specific commands here
+            #self.wait_write(cmd="undo user-security-policy enable", wait="]")
+            #self.wait_write(cmd="undo dcn", wait="]")
+        if getattr(self, "vm_version", None) == "V800R011C00":
+            self.logger.info("Applying config for VRP version V800R011C00")
+            # run R11 specific commands here
+            #self.wait_write(cmd="undo user-security-policy enable", wait="]")
+            #self.wait_write(cmd="undo dcn", wait="]")
+
+    # Default / generic config here
+        self.logger.info("Applying generic bootstrap config...")
+        # ... rest of your existing bootstrap_config logic ...
+
+
         self.bootstrap_mgmt_interface()
         self.wait_write(cmd=f"sysname {self.hostname}", wait="]")
 
@@ -142,6 +217,7 @@ class VRP_vm(vrnetlab.VM):
             self.wait_write(cmd="quit", wait="]")
         if self.vm_type == "NE40E":
             self.wait_write(cmd="undo user-security-policy enable", wait="]")
+            self.wait_write(cmd="undo dcn", wait="]")
 
         self.wait_write(cmd="aaa", wait="]")
         self.wait_write(cmd=f"undo local-user {self.username}", wait="]")
@@ -149,37 +225,73 @@ class VRP_vm(vrnetlab.VM):
             cmd=f"local-user {self.username} password irreversible-cipher {self.password}",
             wait="]",
         )
-        self.wait_write(cmd=f"local-user {self.username} service-type ssh", wait="]")
-        self.wait_write(
-            cmd=f"local-user {self.username} user-group manage-ug", wait="]"
-        )
+        self.wait_write(cmd=f"local-user {self.username} service-type ssh terminal telnet ftp", wait="]")
+        self.wait_write(cmd=f"local-user {self.username} level 3", wait="]")
+
+        self.wait_write(cmd=f"authentication-scheme default_admin", wait="]")
+        self.wait_write(cmd=f"authentication-mode local hwtacacs", wait="]")
+        self.wait_write(cmd="quit", wait="]")
+        self.wait_write(cmd=f"authorization-scheme default_admin", wait="]")
+        self.wait_write(cmd=f"authorization-mode local hwtacacs", wait="]")
+        self.wait_write(cmd="quit", wait="]")
         self.wait_write(cmd="quit", wait="]")
 
-        # SSH
+        # Commit is hanging in the bootstrap with version R23 for unknown reason so we rely on the auto-commit with mmi-mode
+        #self.wait_write(cmd="commit", wait="]")
+        time.sleep(5)
+
+        #self.wait_write(
+        #    cmd=f"local-user {self.username} user-group manage-ug", wait="]"
+        #)
+        #self.wait_write(cmd="quit", wait="]")
+
+        # VTY configuration
         self.wait_write(cmd="user-interface vty 0 4", wait="]")
         self.wait_write(cmd="authentication-mode aaa", wait="]")
-        self.wait_write(cmd="protocol inbound ssh", wait="]")
+        # We want all protocols to be allowed on the vty
+        self.wait_write(cmd="protocol inbound all", wait="]")
+        # We want only ssh to be allowed on the vty
+        #self.wait_write(cmd="protocol inbound ssh", wait="]")
         self.wait_write(cmd="quit", wait="]")
-        self.wait_write(cmd=f"undo ssh user {self.username}", wait="]")
-        self.wait_write(
-            cmd=f"ssh user {self.username} authentication-type password ", wait="]"
-        )
-        self.wait_write(cmd=f"ssh user {self.username} service-type all ", wait="]")
+        
+        # Commit is hanging in the bootstrap with version R23 for unknown reason so we rely on the auto-commit with mmi-mode
+        #self.wait_write(cmd="commit", wait="]")
+        time.sleep(5)
+
+        # Enable stelnet, sftp, scp, ssh
         self.wait_write(cmd="stelnet server enable", wait="]")
+        self.wait_write(cmd="sftp ipv4 server enable", wait="]")
+        self.wait_write(cmd="scp server enable", wait="]")
+        self.wait_write(cmd="ssh authentication-type default password", wait="]")
+        self.wait_write(cmd="ssh server-source all-interface", wait="]")
+        self.wait_write(cmd="sftp server default-directory cfcard:/", wait="]")
 
-        # NETCONF
-        self.wait_write(cmd="snetconf server enable", wait="]")
-        self.wait_write(cmd="netconf", wait="]")
-        self.wait_write(cmd="protocol inbound ssh port 830", wait="]")
+        # Set some ciphers for compatibility
+        self.wait_write(cmd="ssh server cipher aes256_gcm aes128_gcm aes256_ctr aes192_ctr aes128_ctr aes256_cbc aes128_cbc 3des_cbc", wait="]")
+        self.wait_write(cmd="ssh server hmac sha2_512 sha2_256_96 sha2_256 sha1 sha1_96 md5 md5_96", wait="]")
+        self.wait_write(cmd="ssh server key-exchange dh_group_exchange_sha256 dh_group_exchange_sha1 dh_group14_sha1 dh_group1_sha1 ecdh_sha2_nistp256 ecdh_sha2_nistp384 ecdh_sha2_nistp521 sm2_kep dh_group16_sha512 curve25519_sha256", wait="]")
+        self.wait_write(cmd="ssh server publickey dsa ecc rsa rsa_sha2_256 rsa_sha2_512", wait="]")
+        self.wait_write(cmd="ssh server dh-exchange min-len 1024", wait="]")
+        self.wait_write(cmd="ssh client publickey dsa ecc rsa rsa_sha2_256 rsa_sha2_512", wait="]")
+        self.wait_write(cmd="ssh client cipher aes256_gcm aes128_gcm aes256_ctr aes192_ctr aes128_ctr aes256_cbc aes128_cbc 3des_cbc", wait="]")
+        self.wait_write(cmd="ssh client hmac sha2_512 sha2_256_96 sha2_256 sha1 sha1_96 md5 md5_96", wait="]")
+        self.wait_write(cmd="ssh client key-exchange dh_group_exchange_sha256 dh_group_exchange_sha1 dh_group14_sha1 dh_group1_sha1 ecdh_sha2_nistp256 ecdh_sha2_nistp384 ecdh_sha2_nistp521 sm2_kep dh_group16_sha512 curve25519_sha256", wait="]")
+
+
+        # NETCONF seems to crash the virtual R23 router so do not configure it
+        #self.wait_write(cmd="snetconf server enable", wait="]")
+        #self.wait_write(cmd="netconf", wait="]")
+        #self.wait_write(cmd="protocol inbound ssh port 830", wait="]")
+        #self.wait_write(cmd="quit", wait="]")
+
+        time.sleep(5)
+        # We will only do a final quit here and with mmi-mode enable all changes will be commited automatically
         self.wait_write(cmd="quit", wait="]")
+        # if we do not commit we will not see the ">", with mmi-mode enable the system automatically commits when leaving system-view
+        #self.wait_write(cmd="save", wait=">")
+        time.sleep(5)
+        #self.wait_write(cmd="undo mmi-mode enable", wait=">")
 
-        # Reset or undo DCN configuration
-        self.wait_write(cmd="undo dcn", wait="]")
-
-        self.wait_write(cmd="commit", wait="]")
-        self.wait_write(cmd="return", wait="]")
-        self.wait_write(cmd="save", wait=">")
-        self.wait_write(cmd="undo mmi-mode enable", wait=">")
 
     def startup_config(self):
         if not os.path.exists(STARTUP_CONFIG_FILE):
@@ -210,7 +322,7 @@ class VRP_vm(vrnetlab.VM):
 
 
         self.bootstrap_mgmt_interface()
-        self.wait_write(cmd="commit", wait="]")
+        #self.wait_write(cmd="commit", wait="]")
 
 
         self.wait_write(cmd=f"return", wait="]")


### PR DESCRIPTION
Modified huawei_vrp launch.py to extract VRP version, set specific CPU and RAM values for different VRP versions and added an option to run version specific commands during bootstrap configuration.

Added some more detailed comments. Increased some sleep timers (more reliable when starting a lot of container VMs at once because some commands take multiple seconds to get accepted).

Removed/commented the "commit" command in launch.py because it doesn't work for R23 version for whatever reason. But with mmi-mode the system does an auto-commit at final quit (when bootstrap is leaving the router). So, nothing is lost.

Tested successful with ne40e-V800R023, ne40e-V800R022, ne40e-V800R011C00.