### PR TITLE
Fix argparse default password to match DEFAULT_PASSWORD

### DIFF
--- a/sonic/docker/launch.py
+++ b/sonic/docker/launch.py
@@ -145,7 +145,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--hostname", default="sonic", help="SONiC hostname")
     parser.add_argument("--username", default="admin", help="Username")
-    parser.add_argument("--password", default="admin", help="Password")
+    parser.add_argument("--password", default=DEFAULT_PASSWORD, help="Password")
     parser.add_argument(
         "--connection-mode", default="tc", help="Connection mode to use in the datapath"
     )


### PR DESCRIPTION
## Summary

Align the default password in argparse with the constant DEFAULT_PASSWORD (YourPaSsWoRd) to ensure consistency across the codebase.

## Description

Currently, the script defines:
```
DEFAULT_USER = "admin"
DEFAULT_PASSWORD = "YourPaSsWoRd"
```
but the argparse section sets:

```
parser.add_argument("--password", default="admin", help="Password")
```
This causes an inconsistency where:
	•	The VM is initially accessed with the hardcoded DEFAULT_PASSWORD (YourPaSsWoRd).
	•	If no --password is provided, argparse overwrites it with "admin" instead of the intended default.

Fix:
Updated the argparse default for --password to use DEFAULT_PASSWORD.
This ensures:
	•	Default login remains consistent (admin / YourPaSsWoRd).
	•	User-provided --password values continue to override as expected.
