### PR TITLE
Adjust regex for Cat9k build in Makefile

### DIFF
--- a/cisco/cat9kv/Makefile
+++ b/cisco/cat9kv/Makefile
@@ -6,7 +6,7 @@ IMAGE_GLOB=*.qcow2
 # match versions like:
 # csr1000v-universalk9.16.03.01a.qcow2
 # csr1000v-universalk9.16.04.01.qcow2
-VERSION=$(shell echo $(IMAGE) | sed -e 's/.\+[^0-9]\([0-9]\+\.[0-9]\+\.[0-9]\+[a-z]\?\)\([^0-9].*\|$$\)/\1/')
+VERSION=$(shell echo $(IMAGE) | sed -e 's/cat9kv_prd.\(.*\)\.qcow2/\1/')
 
 -include ../../makefile-sanity.include
 -include ../../makefile.include

--- a/cisco/cat9kv/README.md
+++ b/cisco/cat9kv/README.md
@@ -19,6 +19,8 @@ Copy the Cat9kv .qcow2 file in this directory and you can perform `make docker-i
 
 The UADP and Q200 use the same .qcow2 image. The default image created is the UADP image.
 
+> It is possible to tag the UADP and Q200 builds separately by prefixing the version in the filename. For example: `cat9kv_prd.Q200-x.y.z.qcow2` or `cat9kv_prd.UADP-x.y.z.qcow2`
+
 To configure the Q200 image or enable a higher throughput dataplane for UADP; you must supply the relevant `vswitch.xml` file. You can place that file in this directory and build the image.
 
 > You can obtain a `vswitch.xml` file from the relevant CML node definiton file.


### PR DESCRIPTION
Cat9kv can be built with either the UADP or Q200 emulated ASIC. This PR adjusts the regex in the Makefile to be more in line with IOL-XE which allows custom tags to be prepended to the version. This also includes a note in the readme to indicate that the custom image tagging is possible.