### PR TITLE
FT: [FortiGate] Support startup config

### DIFF
--- a/fortinet/fortigate/docker/launch.py
+++ b/fortinet/fortigate/docker/launch.py
@@ -49,8 +49,8 @@ class FOSCliState(IntEnum):
     UNKNOWN = auto()  # Non-patterns from here on.
     TN_TIMEOUT = auto()
 
+DEFAULT_HOSTNAME_PROMPT = rb"(?m)^\s*[A-Za-z0-9_.-]+(?:-VM64)?-KVM(?:\s+\((?:STS|Interim)\))?\s*[#$]\s*"
 
-DEFAULT_HOSTNAME_PROMPT = rb"(?m)^\s*[A-Za-z0-9_.-]+(?:-VM64)?-KVM(?:\s+\([^)]*\))?\s*#\s*"
 FOS_CLI_STATE_PATTERNS = [None] * FOSCliState.UNKNOWN.value
 FOS_CLI_STATE_PATTERNS[FOSCliState.PROVIDE_USERNAME.value] = (
     rb"\n[A-Za-z0-9_.-]+(?:-VM64)?-KVM"
@@ -239,8 +239,8 @@ class FortiOS_vm(vrnetlab.VM):
                 rb"(?m)^ ?"
                 + re.escape(self.hostname.encode("utf-8"))
                 + rb" ?"
-                + rb"(?:\([^)]*\))?"
-                + rb" ?# ?"
+                + rb"(?:\s+\((?:STS|Interim)\))?"
+                + rb" ?[#$] ?"
         )
 
     def _ready(self):

--- a/fortinet/fortigate/docker/launch.py
+++ b/fortinet/fortigate/docker/launch.py
@@ -2,11 +2,11 @@
 import datetime
 import logging
 import os
-from collections import deque
 import re
 import signal
 import sys
 import uuid
+from collections import deque
 from enum import auto, IntEnum
 
 import vrnetlab
@@ -66,6 +66,8 @@ FOS_CLI_STATE_PATTERNS[FOSCliState.CMD_PROMPT.value] = DEFAULT_HOSTNAME_PROMPT
 FOS_CLI_STATE_PATTERNS[FOSCliState.SHUTTING_DOWN.value] = b"system is going down"
 FOS_CLI_STATE_PATTERNS[FOSCliState.REBOOTING.value] = b"stand by while rebooting"
 
+STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
+
 
 class FortiOS_vm(vrnetlab.VM):
     def __init__(self, hostname: str, username, password, conn_mode):
@@ -123,6 +125,7 @@ class FortiOS_vm(vrnetlab.VM):
         self._last_known_state = FOSCliState.UNKNOWN
         self._cmd_queue = deque()
         self._cmd_queue.append(self._update_hostname)
+        self._cmd_queue.append(self._apply_startup_config)
         self._tried_v7_default_password = False
         self._cred_rejected = False
 
@@ -243,6 +246,40 @@ class FortiOS_vm(vrnetlab.VM):
                 + rb"(?:\s+\((?:STS|Interim)\))?"
                 + rb" ?[#$] ?"
         )
+
+    def _apply_startup_config(self):
+        """Load additional config provided by user."""
+
+        if not os.path.exists(STARTUP_CONFIG_FILE):
+            self.logger.trace(f"Startup config file {STARTUP_CONFIG_FILE} is not found")
+            return
+
+        self.logger.trace(f"Configuring with startup-config from file: {STARTUP_CONFIG_FILE}")
+        config_lines = []
+        with open(STARTUP_CONFIG_FILE) as file:
+            config_lines = file.readlines()
+
+        config_stack = deque()
+
+        for line in config_lines:
+            sline = line.strip()
+            if sline.startswith("config"):
+                config_stack.append("c")
+            if sline.startswith("edit"):
+                config_stack.append("e")
+            if sline.startswith("next") or sline.startswith("end"):
+                top = config_stack.pop()
+                if sline.startswith("next") and top != "e":
+                    self.logger.error("Startup config malformed. \"next\" command outside of edit scope.")
+                    raise ValueError("Startup config malformed. \"next\" command outside of edit scope.")
+                if sline.startswith("end") and top != "c":
+                    self.logger.error("Startup config malformed. \"end\" command outside of config scope.")
+                    raise ValueError("Startup config malformed. \"end\" command outside of config scope.")
+            # Maintaining nesting produces a more appealing debug log.
+            self.wait_write(line, wait=None)
+
+        if len(config_stack) > 0:
+            raise ValueError("Startup config malformed. Unmatched config or edit brackets.")
 
     def _ready(self):
         self.running = True

--- a/fortinet/fortigate/docker/launch.py
+++ b/fortinet/fortigate/docker/launch.py
@@ -2,10 +2,12 @@
 import datetime
 import logging
 import os
+from collections import deque
 import re
 import signal
 import sys
 import uuid
+from enum import auto, IntEnum
 
 import vrnetlab
 
@@ -35,12 +37,44 @@ def trace(self, message, *args, **kws):
 logging.Logger.trace = trace
 
 
+class FOSCliState(IntEnum):
+    PROVIDE_USERNAME = 0
+    PROVIDE_PASSWORD = auto()
+    CHANGE_PASSWORD = auto()
+    CREDENTIAL_REJECTED = auto()
+    CREDENTIAL_ACCEPTED = auto()
+    CMD_PROMPT = auto()
+    SHUTTING_DOWN = auto()
+    REBOOTING = auto()
+    UNKNOWN = auto()  # Non-patterns from here on.
+    TN_TIMEOUT = auto()
+
+
+DEFAULT_HOSTNAME_PROMPT = rb"(?m)^\s*[A-Za-z0-9_.-]+(?:-VM64)?-KVM(?:\s+\([^)]*\))?\s*#\s*"
+FOS_CLI_STATE_PATTERNS = [None] * FOSCliState.UNKNOWN.value
+FOS_CLI_STATE_PATTERNS[FOSCliState.PROVIDE_USERNAME.value] = (
+    rb"\n[A-Za-z0-9_.-]+(?:-VM64)?-KVM"
+    rb"(?:\((?:Primary|Secondary)\))?"
+    rb"\s+login:\s*"
+)
+FOS_CLI_STATE_PATTERNS[FOSCliState.CHANGE_PASSWORD.value] = b"(?m)^New Password:"
+FOS_CLI_STATE_PATTERNS[FOSCliState.PROVIDE_PASSWORD.value] = b"(?m)^Password:"
+FOS_CLI_STATE_PATTERNS[FOSCliState.CREDENTIAL_REJECTED.value] = rb"(?m)^Login incorrect\r?$"
+FOS_CLI_STATE_PATTERNS[FOSCliState.CREDENTIAL_ACCEPTED.value] = rb"(?m)^Welcome ?!\r?$"
+FOS_CLI_STATE_PATTERNS[FOSCliState.CMD_PROMPT.value] = DEFAULT_HOSTNAME_PROMPT
+FOS_CLI_STATE_PATTERNS[FOSCliState.SHUTTING_DOWN.value] = b"system is going down"
+FOS_CLI_STATE_PATTERNS[FOSCliState.REBOOTING.value] = b"stand by while rebooting"
+
+
 class FortiOS_vm(vrnetlab.VM):
-    def __init__(self, hostname, username, password, conn_mode):
+    def __init__(self, hostname: str, username, password, conn_mode):
+        disk_image = None
         for e in os.listdir("."):
             if re.search(".qcow2$", e):
                 disk_image = "./" + e
-        # call parents __init__ function here
+        if disk_image is None:
+            self.logger.critical("Failed to find device image")
+            raise RuntimeError("Could not find image to boot")
         super(FortiOS_vm, self).__init__(
             username,
             password,
@@ -71,7 +105,25 @@ class FortiOS_vm(vrnetlab.VM):
                 "if=virtio,format=qcow2,file=empty.qcow2,index=1",
             ]
         )
-
+        self._state_patterns = FOS_CLI_STATE_PATTERNS.copy()
+        self._state_handlers = {
+            FOSCliState.PROVIDE_USERNAME: self._provide_username,
+            FOSCliState.PROVIDE_PASSWORD: self._provide_password,
+            FOSCliState.CHANGE_PASSWORD: self._change_password,
+            FOSCliState.CREDENTIAL_REJECTED: self._credential_rejected,
+            FOSCliState.CREDENTIAL_ACCEPTED: self._credential_accepted,
+            FOSCliState.CMD_PROMPT: self._cmd_prompt,
+            FOSCliState.SHUTTING_DOWN: self._shutting_down,
+            FOSCliState.REBOOTING: self._rebooting,
+            FOSCliState.UNKNOWN: self._unknown_state,
+            FOSCliState.TN_TIMEOUT: self._tn_timeout,
+        }
+        self.tn_out = b""
+        self._last_known_state = FOSCliState.UNKNOWN
+        self._cmd_queue = deque()
+        self._cmd_queue.append(self._update_hostname)
+        self._tried_v7_default_password = False
+        self._cred_rejected = False
 
     def bootstrap_spin(self):
         """This function should be called periodically to do work.
@@ -79,66 +131,124 @@ class FortiOS_vm(vrnetlab.VM):
         returns False when it has failed and given up, otherwise True
         """
         if self.spins > 300:
-            # too many spins with no result -> restart
+            # too many spins without appropriate communication
             self.logger.warning("no output from serial console, restarting VCP")
             self.stop()
-            self.start()
             self.spins = 0
+            raise RuntimeError("VM node malfunction")
+        cur_state = self._next_state()
+
+        # The FSM is actually moving along
+        if cur_state.value < FOSCliState.UNKNOWN.value:
+            self.spins = 0
+            self._last_known_state = cur_state
+
+        # Continue to show current state while reducing verbosity
+        if cur_state != FOSCliState.UNKNOWN and cur_state != FOSCliState.TN_TIMEOUT:
+            self.logger.debug(f"ST: {cur_state.name}")
+
+        if len(self.tn_out) > 0:
+            self.logger.debug(f"OUT: {self.tn_out}")
+
+        self._state_handlers[cur_state]()
+
+    def _next_state(self):
+        (ridx, match, res) = self.tn.expect(self._state_patterns, 1)
+        self.tn_out = res
+        if not match:
+            if res == b"":
+                return FOSCliState.TN_TIMEOUT
+            return FOSCliState.UNKNOWN
+        return FOSCliState(ridx)
+
+    def _provide_username(self):
+        self.wait_write(self.username, wait=None)
+
+    def _provide_password(self):
+        if self._cred_rejected:
+            self._tried_v7_default_password = True
+            self.wait_write("", wait=None)
             return
+        self.wait_write(self.password, wait=None)
 
-        (ridx, match, res) = self.tn.expect([b"login:", b"FortiGate-VM64-KVM #"], 1)
-        if match:  # got a match!
-            if ridx == 0:  # matched login prompt, so should login
-                self.logger.debug("ridx == 0")
-                self.logger.info("matched login prompt")
+    def _change_password(self):
+        self.wait_write(self.password, wait=None)
+        self.wait_write(self.password, wait="Confirm Password")
+        self._password_changed = True
+        # FOS 7.4 needs log out before you can use the password with ssh
+        self._cmd_queue.appendleft(lambda: self.wait_write("exit", wait=None))
 
-                self.wait_write(self.username, wait=None)
-                self.wait_write("", wait=self.username)
-                self.wait_write(self.password, wait="Password")
-                self.wait_write(self.password, wait=None)
+    def _credential_accepted(self):
+        self._cred_rejected = False
+        self._tried_v7_default_password = False
 
-            if ridx == 1:
-                # if we dont match the FortiGate-VM64-KVM # we assume we already have some configuration and
-                # may continue with configure the system to our needs.
-                self.logger.debug("ridx == 1")
-                self.wait_write("config system global", wait=None)
-                hostname_command = "set hostname " + self.hostname
-                self.wait_write(hostname_command, wait="global")
-                self.wait_write("end", wait=hostname_command)
-                self.running = True
-                self.tn.close()
-                # calc startup time
-                startup_time = datetime.datetime.now() - self.start_time
-                self.logger.info(f"Startup complete in { startup_time }")
-                return
+    def _cmd_prompt(self):
+        try:
+            next_cmd = self._cmd_queue.popleft()
+        except IndexError:
+            self._cmd_queue.append(self._ready)
+            return
+        next_cmd()
 
+    def _shutting_down(self):
+        pass
+
+    def _rebooting(self):
+        pass
+
+    def _credential_rejected(self):
+        if not self._tried_v7_default_password:
+            self.logger.debug("Credential rejected. Possibly never configured. Trying default password next time.")
+            self._cred_rejected = True
+            return
+        additional_info = ""
+        if b"pasword policy" in self.tn_out:
+            additional_info = "Min password policy not met. Check the logs for the password policy"
+        self.logger.error(f"Credential rejected. {additional_info}")
+
+        self.running = False
+        self.tn.close()
+        self.stop()
+        raise RuntimeError("Credential rejected")
+
+    def _unknown_state(self):
+        # no match, if we saw some output from the router it's probably
+        # booting, so let's give it some more time
+        if self._last_known_state == FOSCliState.REBOOTING:
+            self.spins += 1
+            # It could be that the FGT image was defective. In this case it has been observed that
+            # the FGT would endlessly reboot.
         else:
-            # no match, if we saw some output from the router it's probably
-            # booting, so let's give it some more time
-            if res != b"":
-                self.logger.trace(f"OUTPUT FORTIGATE: {res.decode()}")
-                # reset spins if we saw some output
-                self.spins = 0
+            self.spins = 0
 
+    def _tn_timeout(self):
+        if self._last_known_state == FOSCliState.CMD_PROMPT:
+            self._cmd_prompt()
         self.spins += 1
 
-    def _wait_reset(self):
-        """
-        This function waits for the login prompt after the VM was resetted.
-        If commands are issued that enforce a reboot this comes in hand.
-        e.g factoryreset or factoryreset2
-        """
-        self.logger.debug("waiting for reset")
-        wait_spins = 0
-        while wait_spins < 90:
-            _, match, data = self.tn.expect([b"login: "], timeout=10)
-            self.logger.trace(data.decode("UTF-8"))
-            if match:
-                self.logger.debug("reset finished")
-                return True
-            wait_spins += 1
-        self.logger.error("Reset took to long")
-        return False
+    def _update_hostname(self):
+        self.wait_write("config system global", wait=None)
+        hostname_command = "set hostname " + self.hostname
+        self.wait_write(hostname_command, wait="global")
+        self.wait_write("end", wait=hostname_command)
+        self._state_patterns[FOSCliState.PROVIDE_USERNAME.value] = (
+                rb"\n" + self.hostname.encode("utf-8") +
+                rb"(?:\((?:Primary|Secondary)\))?" +
+                rb"\s+login:\s*")
+        self._state_patterns[FOSCliState.CMD_PROMPT.value] = (
+                rb"(?m)^ ?"
+                + re.escape(self.hostname.encode("utf-8"))
+                + rb" ?"
+                + rb"(?:\([^)]*\))?"
+                + rb" ?# ?"
+        )
+
+    def _ready(self):
+        self.running = True
+        self.tn.close()
+        # calc startup time
+        startup_time = datetime.datetime.now() - self.start_time
+        self.logger.info(f"Startup complete in {startup_time}")
 
 
 class FortiOS(vrnetlab.VR):

--- a/fortinet/fortigate/docker/launch.py
+++ b/fortinet/fortigate/docker/launch.py
@@ -49,11 +49,12 @@ class FOSCliState(IntEnum):
     UNKNOWN = auto()  # Non-patterns from here on.
     TN_TIMEOUT = auto()
 
-DEFAULT_HOSTNAME_PROMPT = rb"(?m)^\s*[A-Za-z0-9_.-]+(?:-VM64)?-KVM(?:\s+\((?:STS|Interim)\))?\s*[#$]\s*"
 
+DEFAULT_HOSTNAME_REGEX = rb"[A-Za-z0-9_.-]+(?:-VM64)?-KVM(?:-[A-Za-z0-9]*)?"
+DEFAULT_HOSTNAME_PROMPT = rb"(?m)^\s*" + DEFAULT_HOSTNAME_REGEX + rb"(?:\s+\((?:STS|Interim)\))?\s*[#$]\s*"
 FOS_CLI_STATE_PATTERNS = [None] * FOSCliState.UNKNOWN.value
 FOS_CLI_STATE_PATTERNS[FOSCliState.PROVIDE_USERNAME.value] = (
-    rb"\n[A-Za-z0-9_.-]+(?:-VM64)?-KVM"
+    rb"\n" + DEFAULT_HOSTNAME_REGEX +
     rb"(?:\((?:Primary|Secondary)\))?"
     rb"\s+login:\s*"
 )


### PR DESCRIPTION
## Purpose

Depends on #463 

To add support for startup config in Fortinet devices. The implementation is minimal and the only validation it performs
is ensure matching config-end, edit-next braces such to prevent the FSM from being stock due to not returning to the global scope. 

At this point I chose not to add more validation to limit the complexity of the implementation. The config back ups from FTNT devices can contain fields that cannot be directly set and that may cause an error to be displayed. A more robust validation framework would be beneficial such that the user can  be warned, but edge cases like these would have to be handled. This can be added at a later date. 

## Changes

- Read startup-config from standard location at /config/startup-config.cfg
- Pass config to FTNT VM
- Validate all braces are matched

## Testing

Tested on:
FGT 8.0.0 build0167 GA (Debug)

TEST: Start VM with config ok.
EXPECTED: Config is fully applied
RESULT: SUCCESS


TEST: Start VM with config ok with missing end bracket
EXPECTED: VM launch fails. An appropriate message is shown in the logs.
RESULT: SUCCESS

TEST: Start VM with config ok with missing next bracket
EXPECTED: VM launch fails. An appropriate message is shown in the logs.
RESULT: SUCCESS

TEST: Start VM with config ok with end bracket closing edit scope. 
EXPECTED: VM launch fails. An appropriate message is shown in the logs.
RESULT: SUCCESS

TEST: Start VM with config ok with next bracket closing config scope
EXPECTED: VM launch fails. An appropriate message is shown in the logs.
RESULT: SUCCESS