### PR TITLE
FT: [FortiGate] Support pass-through management

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ _Pass-through management_ interfaces allows the use of the assigned management I
 
 NOSes defaulting to _pass-through_ management interfaces are:
 
-* None so far, we are gathering feedback on this, and will update this list as feedback is received. Please contact us in [Discord](https://discord.gg/vAyddtaEV9) or open up an issue here if you have found any issues when trying the passthrough mode.
+we are gathering feedback on this, and will update this list as feedback is received. Please contact us in [Discord](https://discord.gg/vAyddtaEV9) or open up an issue here if you have found any issues when trying the passthrough mode.
+* Fortinet/Fortigate
 
 In case of _host-forwarded_ management interfaces, certain ports are forwarded to the NOS VM IP, which is always 10.0.0.15/24. The management gateway in this case is 10.0.0.2/24, and outgoing traffic is NATed to the container management IP. This management interface connection mode does not allow for traffic such as LLDP to pass through the management interface.
 

--- a/fortinet/fortigate/docker/README.md
+++ b/fortinet/fortigate/docker/README.md
@@ -10,3 +10,52 @@ Naming format: fortios-vX.Y.Z.qcow2
 
 ## Running the docker image
 `make docker-run-fortigate`
+
+
+## Usage notes
+
+### host-forwarded management interface
+
+If using this mode with DHCP, a default route will be created using the DHCP 
+configuration. This can collide with your need to have a default route in your
+lab. You can resolve this by applying this config:
+
+config router static
+    edit <route-id>
+        set dst <mgmt subnet>
+        set gateway <QEMU gateway>
+        set port port1
+    next
+end
+
+config system interface
+    edit port1
+       set defaultgw disable
+    next
+end
+
+**Setting defaultgw disable before the route is ready will cause connection-loss**
+
+The QEMU Gateway you can find like this:
+
+While still having defaultgw enabled run:
+
+```
+get router info routing-table 
+
+br-fgt (Interim)# get router info routing-table details 
+Codes: K - kernel, C - connected, S - static, R - RIP, B - BGP
+       O - OSPF, IA - OSPF inter area
+       N1 - OSPF NSSA external type 1, N2 - OSPF NSSA external type 2
+       E1 - OSPF external type 1, E2 - OSPF external type 2
+       i - IS-IS, L1 - IS-IS level-1, L2 - IS-IS level-2, ia - IS-IS inter area
+       V - BGP VPNv4, E - BGP EVPN, L - Leaked, D - Directly leaked
+       * - candidate default
+
+Routing table for VRF=0
+S*      0.0.0.0/0 [5/0] via 10.0.0.2, port1, [1/0] <-------THIS ONE
+C       10.0.0.0/24 is directly connected, port1
+C       10.10.49.0/24 is directly connected, port2
+C       198.18.0.0/30 is directly connected, port3
+
+```

--- a/fortinet/fortigate/docker/launch.py
+++ b/fortinet/fortigate/docker/launch.py
@@ -49,8 +49,8 @@ class FOSCliState(IntEnum):
     UNKNOWN = auto()  # Non-patterns from here on.
     TN_TIMEOUT = auto()
 
+DEFAULT_HOSTNAME_PROMPT = rb"(?m)^\s*[A-Za-z0-9_.-]+(?:-VM64)?-KVM(?:\s+\((?:STS|Interim)\))?\s*[#$]\s*"
 
-DEFAULT_HOSTNAME_PROMPT = rb"(?m)^\s*[A-Za-z0-9_.-]+(?:-VM64)?-KVM(?:\s+\([^)]*\))?\s*#\s*"
 FOS_CLI_STATE_PATTERNS = [None] * FOSCliState.UNKNOWN.value
 FOS_CLI_STATE_PATTERNS[FOSCliState.PROVIDE_USERNAME.value] = (
     rb"\n[A-Za-z0-9_.-]+(?:-VM64)?-KVM"
@@ -239,8 +239,8 @@ class FortiOS_vm(vrnetlab.VM):
                 rb"(?m)^ ?"
                 + re.escape(self.hostname.encode("utf-8"))
                 + rb" ?"
-                + rb"(?:\([^)]*\))?"
-                + rb" ?# ?"
+                + rb"(?:\s+\((?:STS|Interim)\))?"
+                + rb" ?[#$] ?"
         )
 
     def _ready(self):

--- a/fortinet/fortigate/docker/launch.py
+++ b/fortinet/fortigate/docker/launch.py
@@ -86,7 +86,7 @@ class FortiOS_vm(vrnetlab.VM):
             driveif="virtio",
             # fortios fails to respond to network requests if the pci bus is setup :D
             provision_pci_bus=False,
-            mgmt_passthrough=True,
+            mgmt_passthrough=True
         )
         self.conn_mode = conn_mode
         self.hostname = hostname
@@ -126,7 +126,9 @@ class FortiOS_vm(vrnetlab.VM):
         self._last_known_state = FOSCliState.UNKNOWN
         self._cmd_queue = deque()
         if self.mgmt_passthrough:
-            self._cmd_queue.append(self._apply_mgmt_ip)
+            self._cmd_queue.append(self._apply_mgmt_ip_passthrough)
+        else:
+            self._cmd_queue.append(self._apply_mgmt_ip_host_forwarded)
         self._cmd_queue.append(self._update_hostname)
         self._cmd_queue.append(self._apply_startup_config)
         self._tried_v7_default_password = False
@@ -237,7 +239,7 @@ class FortiOS_vm(vrnetlab.VM):
 
     # === COMMANDS ===
 
-    def _apply_mgmt_ip(self):
+    def _apply_mgmt_ip_passthrough(self):
         if self.mgmt_address_ipv4 == "dhcp":
             self.logger("MGMT IP is in DHCP mode")
             return
@@ -245,7 +247,8 @@ class FortiOS_vm(vrnetlab.VM):
         self.wait_write("config system interface\r"
                         "edit port1\r"
                         "set mode static\r"
-                        f"set ip {self.mgmt_address_ipv4}",
+                        f"set ip {self.mgmt_address_ipv4}\r"
+                        "set vrf 1",
                         wait=None)
         if self.mgmt_address_ipv6 is not None:
             self.wait_write("config ipv6\r"
@@ -257,6 +260,14 @@ class FortiOS_vm(vrnetlab.VM):
         self.wait_write("next\r"
                         "end",
                         wait=None)
+
+    def _apply_mgmt_ip_host_forwarded(self):
+        self.wait_write("config system interface\r"
+                        "edit port1"
+                        , wait=None)
+        self.wait_write("set vrf 1\r"
+                        "next\r"
+                        "end", wait="(port1)")
 
     def _update_hostname(self):
         self.wait_write("config system global", wait=None)

--- a/fortinet/fortigate/docker/launch.py
+++ b/fortinet/fortigate/docker/launch.py
@@ -2,11 +2,11 @@
 import datetime
 import logging
 import os
-from collections import deque
 import re
 import signal
 import sys
 import uuid
+from collections import deque
 from enum import auto, IntEnum
 
 import vrnetlab
@@ -66,6 +66,8 @@ FOS_CLI_STATE_PATTERNS[FOSCliState.CMD_PROMPT.value] = DEFAULT_HOSTNAME_PROMPT
 FOS_CLI_STATE_PATTERNS[FOSCliState.SHUTTING_DOWN.value] = b"system is going down"
 FOS_CLI_STATE_PATTERNS[FOSCliState.REBOOTING.value] = b"stand by while rebooting"
 
+STARTUP_CONFIG_FILE = "/config/startup-config.cfg"
+
 
 class FortiOS_vm(vrnetlab.VM):
     def __init__(self, hostname: str, username, password, conn_mode):
@@ -123,6 +125,7 @@ class FortiOS_vm(vrnetlab.VM):
         self._last_known_state = FOSCliState.UNKNOWN
         self._cmd_queue = deque()
         self._cmd_queue.append(self._update_hostname)
+        self._cmd_queue.append(self._apply_startup_config)
         self._tried_v7_default_password = False
         self._cred_rejected = False
 
@@ -243,6 +246,40 @@ class FortiOS_vm(vrnetlab.VM):
                 + rb"(?:\s+\((?:STS|Interim)\))?"
                 + rb" ?[#$] ?"
         )
+
+    def _apply_startup_config(self):
+        """Load additional config provided by user."""
+
+        if not os.path.exists(STARTUP_CONFIG_FILE):
+            self.logger.trace(f"Startup config file {STARTUP_CONFIG_FILE} is not found")
+            return
+
+        self.logger.trace(f"Configuring with startup-config from file: {STARTUP_CONFIG_FILE}")
+        config_lines = []
+        with open(STARTUP_CONFIG_FILE) as file:
+            config_lines = file.readlines()
+
+        config_stack = deque()
+
+        for line in config_lines:
+            sline = line.strip()
+            if sline.startswith("config"):
+                config_stack.append("c")
+            if sline.startswith("edit"):
+                config_stack.append("e")
+            if sline.startswith("next") or sline.startswith("end"):
+                top = config_stack.pop()
+                if sline.startswith("next") and top != "e":
+                    self.logger.error("Startup config malformed. \"next\" command outside of edit scope.")
+                    raise ValueError("Startup config malformed. \"next\" command outside of edit scope.")
+                if sline.startswith("end") and top != "c":
+                    self.logger.error("Startup config malformed. \"end\" command outside of config scope.")
+                    raise ValueError("Startup config malformed. \"end\" command outside of config scope.")
+            # Maintaining nesting produces a more appealing debug log.
+            self.wait_write(line, wait=None)
+
+        if len(config_stack) > 0:
+            raise ValueError("Startup config malformed. Unmatched config or edit brackets.")
 
     def _ready(self):
         self.running = True

--- a/fortinet/fortigate/docker/launch.py
+++ b/fortinet/fortigate/docker/launch.py
@@ -2,10 +2,12 @@
 import datetime
 import logging
 import os
+from collections import deque
 import re
 import signal
 import sys
 import uuid
+from enum import auto, IntEnum
 
 import vrnetlab
 
@@ -35,12 +37,44 @@ def trace(self, message, *args, **kws):
 logging.Logger.trace = trace
 
 
+class FOSCliState(IntEnum):
+    PROVIDE_USERNAME = 0
+    PROVIDE_PASSWORD = auto()
+    CHANGE_PASSWORD = auto()
+    CREDENTIAL_REJECTED = auto()
+    CREDENTIAL_ACCEPTED = auto()
+    CMD_PROMPT = auto()
+    SHUTTING_DOWN = auto()
+    REBOOTING = auto()
+    UNKNOWN = auto()  # Non-patterns from here on.
+    TN_TIMEOUT = auto()
+
+
+DEFAULT_HOSTNAME_PROMPT = rb"(?m)^\s*[A-Za-z0-9_.-]+(?:-VM64)?-KVM(?:\s+\([^)]*\))?\s*#\s*"
+FOS_CLI_STATE_PATTERNS = [None] * FOSCliState.UNKNOWN.value
+FOS_CLI_STATE_PATTERNS[FOSCliState.PROVIDE_USERNAME.value] = (
+    rb"\n[A-Za-z0-9_.-]+(?:-VM64)?-KVM"
+    rb"(?:\((?:Primary|Secondary)\))?"
+    rb"\s+login:\s*"
+)
+FOS_CLI_STATE_PATTERNS[FOSCliState.CHANGE_PASSWORD.value] = b"(?m)^New Password:"
+FOS_CLI_STATE_PATTERNS[FOSCliState.PROVIDE_PASSWORD.value] = b"(?m)^Password:"
+FOS_CLI_STATE_PATTERNS[FOSCliState.CREDENTIAL_REJECTED.value] = rb"(?m)^Login incorrect\r?$"
+FOS_CLI_STATE_PATTERNS[FOSCliState.CREDENTIAL_ACCEPTED.value] = rb"(?m)^Welcome ?!\r?$"
+FOS_CLI_STATE_PATTERNS[FOSCliState.CMD_PROMPT.value] = DEFAULT_HOSTNAME_PROMPT
+FOS_CLI_STATE_PATTERNS[FOSCliState.SHUTTING_DOWN.value] = b"system is going down"
+FOS_CLI_STATE_PATTERNS[FOSCliState.REBOOTING.value] = b"stand by while rebooting"
+
+
 class FortiOS_vm(vrnetlab.VM):
-    def __init__(self, hostname, username, password, conn_mode):
+    def __init__(self, hostname: str, username, password, conn_mode):
+        disk_image = None
         for e in os.listdir("."):
             if re.search(".qcow2$", e):
                 disk_image = "./" + e
-        # call parents __init__ function here
+        if disk_image is None:
+            self.logger.critical("Failed to find device image")
+            raise RuntimeError("Could not find image to boot")
         super(FortiOS_vm, self).__init__(
             username,
             password,
@@ -71,7 +105,25 @@ class FortiOS_vm(vrnetlab.VM):
                 "if=virtio,format=qcow2,file=empty.qcow2,index=1",
             ]
         )
-
+        self._state_patterns = FOS_CLI_STATE_PATTERNS.copy()
+        self._state_handlers = {
+            FOSCliState.PROVIDE_USERNAME: self._provide_username,
+            FOSCliState.PROVIDE_PASSWORD: self._provide_password,
+            FOSCliState.CHANGE_PASSWORD: self._change_password,
+            FOSCliState.CREDENTIAL_REJECTED: self._credential_rejected,
+            FOSCliState.CREDENTIAL_ACCEPTED: self._credential_accepted,
+            FOSCliState.CMD_PROMPT: self._cmd_prompt,
+            FOSCliState.SHUTTING_DOWN: self._shutting_down,
+            FOSCliState.REBOOTING: self._rebooting,
+            FOSCliState.UNKNOWN: self._unknown_state,
+            FOSCliState.TN_TIMEOUT: self._tn_timeout,
+        }
+        self.tn_out = b""
+        self._last_known_state = FOSCliState.UNKNOWN
+        self._cmd_queue = deque()
+        self._cmd_queue.append(self._update_hostname)
+        self._tried_v7_default_password = False
+        self._cred_rejected = False
 
     def bootstrap_spin(self):
         """This function should be called periodically to do work.
@@ -79,66 +131,124 @@ class FortiOS_vm(vrnetlab.VM):
         returns False when it has failed and given up, otherwise True
         """
         if self.spins > 300:
-            # too many spins with no result -> restart
+            # too many spins without appropriate communication
             self.logger.warning("no output from serial console, restarting VCP")
             self.stop()
-            self.start()
             self.spins = 0
+            raise RuntimeError("VM node malfunction")
+        cur_state = self._next_state()
+
+        # The FSM is actually moving along
+        if cur_state.value < FOSCliState.UNKNOWN.value:
+            self.spins = 0
+            self._last_known_state = cur_state
+
+        # Continue to show current state while reducing verbosity
+        if cur_state != FOSCliState.UNKNOWN and cur_state != FOSCliState.TN_TIMEOUT:
+            self.logger.debug(f"ST: {cur_state.name}")
+
+        if len(self.tn_out) > 0:
+            self.logger.debug(f"OUT: {self.tn_out}")
+
+        self._state_handlers[cur_state]()
+
+    def _next_state(self):
+        (ridx, match, res) = self.tn.expect(self._state_patterns, 1)
+        self.tn_out = res
+        if not match:
+            if res == b"":
+                return FOSCliState.TN_TIMEOUT
+            return FOSCliState.UNKNOWN
+        return FOSCliState(ridx)
+
+    def _provide_username(self):
+        self.wait_write(self.username, wait=None)
+
+    def _provide_password(self):
+        if self._cred_rejected:
+            self._tried_v7_default_password = True
+            self.wait_write("", wait=None)
             return
+        self.wait_write(self.password, wait=None)
 
-        (ridx, match, res) = self.tn.expect([b"login:", b"FortiGate-VM64-KVM #"], 1)
-        if match:  # got a match!
-            if ridx == 0:  # matched login prompt, so should login
-                self.logger.debug("ridx == 0")
-                self.logger.info("matched login prompt")
+    def _change_password(self):
+        self.wait_write(self.password, wait=None)
+        self.wait_write(self.password, wait="Confirm Password")
+        self._password_changed = True
+        # FOS 7.4 needs log out before you can use the password with ssh
+        self._cmd_queue.appendleft(lambda: self.wait_write("exit", wait=None))
 
-                self.wait_write(self.username, wait=None)
-                self.wait_write("", wait=self.username)
-                self.wait_write(self.password, wait="Password")
-                self.wait_write(self.password, wait=None)
+    def _credential_accepted(self):
+        self._cred_rejected = False
+        self._tried_v7_default_password = False
 
-            if ridx == 1:
-                # if we dont match the FortiGate-VM64-KVM # we assume we already have some configuration and
-                # may continue with configure the system to our needs.
-                self.logger.debug("ridx == 1")
-                self.wait_write("config system global", wait=None)
-                hostname_command = "set hostname " + self.hostname
-                self.wait_write(hostname_command, wait="global")
-                self.wait_write("end", wait=hostname_command)
-                self.running = True
-                self.tn.close()
-                # calc startup time
-                startup_time = datetime.datetime.now() - self.start_time
-                self.logger.info(f"Startup complete in { startup_time }")
-                return
+    def _cmd_prompt(self):
+        try:
+            next_cmd = self._cmd_queue.popleft()
+        except IndexError:
+            self._cmd_queue.append(self._ready)
+            return
+        next_cmd()
 
+    def _shutting_down(self):
+        pass
+
+    def _rebooting(self):
+        pass
+
+    def _credential_rejected(self):
+        if not self._tried_v7_default_password:
+            self.logger.debug("Credential rejected. Possibly never configured. Trying default password next time.")
+            self._cred_rejected = True
+            return
+        additional_info = ""
+        if b"pasword policy" in self.tn_out:
+            additional_info = "Min password policy not met. Check the logs for the password policy"
+        self.logger.error(f"Credential rejected. {additional_info}")
+
+        self.running = False
+        self.tn.close()
+        self.stop()
+        raise RuntimeError("Credential rejected")
+
+    def _unknown_state(self):
+        # no match, if we saw some output from the router it's probably
+        # booting, so let's give it some more time
+        if self._last_known_state == FOSCliState.REBOOTING:
+            self.spins += 1
+            # It could be that the FGT image was defective. In this case it has been observed that
+            # the FGT would endlessly reboot.
         else:
-            # no match, if we saw some output from the router it's probably
-            # booting, so let's give it some more time
-            if res != b"":
-                self.logger.trace(f"OUTPUT FORTIGATE: {res.decode()}")
-                # reset spins if we saw some output
-                self.spins = 0
+            self.spins = 0
 
+    def _tn_timeout(self):
+        if self._last_known_state == FOSCliState.CMD_PROMPT:
+            self._cmd_prompt()
         self.spins += 1
 
-    def _wait_reset(self):
-        """
-        This function waits for the login prompt after the VM was resetted.
-        If commands are issued that enforce a reboot this comes in hand.
-        e.g factoryreset or factoryreset2
-        """
-        self.logger.debug("waiting for reset")
-        wait_spins = 0
-        while wait_spins < 90:
-            _, match, data = self.tn.expect([b"login: "], timeout=10)
-            self.logger.trace(data.decode("UTF-8"))
-            if match:
-                self.logger.debug("reset finished")
-                return True
-            wait_spins += 1
-        self.logger.error("Reset took to long")
-        return False
+    def _update_hostname(self):
+        self.wait_write("config system global", wait=None)
+        hostname_command = "set hostname " + self.hostname
+        self.wait_write(hostname_command, wait="global")
+        self.wait_write("end", wait=hostname_command)
+        self._state_patterns[FOSCliState.PROVIDE_USERNAME.value] = (
+                rb"\n" + self.hostname.encode("utf-8") +
+                rb"(?:\((?:Primary|Secondary)\))?" +
+                rb"\s+login:\s*")
+        self._state_patterns[FOSCliState.CMD_PROMPT.value] = (
+                rb"(?m)^ ?"
+                + re.escape(self.hostname.encode("utf-8"))
+                + rb" ?"
+                + rb"(?:\([^)]*\))?"
+                + rb" ?# ?"
+        )
+
+    def _ready(self):
+        self.running = True
+        self.tn.close()
+        # calc startup time
+        startup_time = datetime.datetime.now() - self.start_time
+        self.logger.info(f"Startup complete in {startup_time}")
 
 
 class FortiOS(vrnetlab.VR):

--- a/fortinet/fortigate/docker/launch.py
+++ b/fortinet/fortigate/docker/launch.py
@@ -86,6 +86,7 @@ class FortiOS_vm(vrnetlab.VM):
             driveif="virtio",
             # fortios fails to respond to network requests if the pci bus is setup :D
             provision_pci_bus=False,
+            mgmt_passthrough=True,
         )
         self.conn_mode = conn_mode
         self.hostname = hostname
@@ -124,6 +125,8 @@ class FortiOS_vm(vrnetlab.VM):
         self.tn_out = b""
         self._last_known_state = FOSCliState.UNKNOWN
         self._cmd_queue = deque()
+        if self.mgmt_passthrough:
+            self._cmd_queue.append(self._apply_mgmt_ip)
         self._cmd_queue.append(self._update_hostname)
         self._cmd_queue.append(self._apply_startup_config)
         self._tried_v7_default_password = False
@@ -164,6 +167,8 @@ class FortiOS_vm(vrnetlab.VM):
                 return FOSCliState.TN_TIMEOUT
             return FOSCliState.UNKNOWN
         return FOSCliState(ridx)
+
+    # === STATE HANDLERS ===
 
     def _provide_username(self):
         self.wait_write(self.username, wait=None)
@@ -229,6 +234,29 @@ class FortiOS_vm(vrnetlab.VM):
         if self._last_known_state == FOSCliState.CMD_PROMPT:
             self._cmd_prompt()
         self.spins += 1
+
+    # === COMMANDS ===
+
+    def _apply_mgmt_ip(self):
+        if self.mgmt_address_ipv4 == "dhcp":
+            self.logger("MGMT IP is in DHCP mode")
+            return
+        self.logger.info(f"Setting mgmt IPv4={self.mgmt_address_ipv4} and IPv6={self.mgmt_address_ipv6}")
+        self.wait_write("config system interface\r"
+                        "edit port1\r"
+                        "set mode static\r"
+                        f"set ip {self.mgmt_address_ipv4}",
+                        wait=None)
+        if self.mgmt_address_ipv6 is not None:
+            self.wait_write("config ipv6\r"
+                            "set ip6-mode static\r"
+                            f"set ip6-address {self.mgmt_address_ipv6}\r"
+                            "set ip6-allowaccess ping https ssh http\r"
+                            "end",
+                            wait=None)
+        self.wait_write("next\r"
+                        "end",
+                        wait=None)
 
     def _update_hostname(self):
         self.wait_write("config system global", wait=None)

--- a/fortinet/fortigate/docker/launch.py
+++ b/fortinet/fortigate/docker/launch.py
@@ -49,11 +49,12 @@ class FOSCliState(IntEnum):
     UNKNOWN = auto()  # Non-patterns from here on.
     TN_TIMEOUT = auto()
 
-DEFAULT_HOSTNAME_PROMPT = rb"(?m)^\s*[A-Za-z0-9_.-]+(?:-VM64)?-KVM(?:\s+\((?:STS|Interim)\))?\s*[#$]\s*"
 
+DEFAULT_HOSTNAME_REGEX = rb"[A-Za-z0-9_.-]+(?:-VM64)?-KVM(?:-[A-Za-z0-9]*)?"
+DEFAULT_HOSTNAME_PROMPT = rb"(?m)^\s*" + DEFAULT_HOSTNAME_REGEX + rb"(?:\s+\((?:STS|Interim)\))?\s*[#$]\s*"
 FOS_CLI_STATE_PATTERNS = [None] * FOSCliState.UNKNOWN.value
 FOS_CLI_STATE_PATTERNS[FOSCliState.PROVIDE_USERNAME.value] = (
-    rb"\n[A-Za-z0-9_.-]+(?:-VM64)?-KVM"
+    rb"\n" + DEFAULT_HOSTNAME_REGEX +
     rb"(?:\((?:Primary|Secondary)\))?"
     rb"\s+login:\s*"
 )


### PR DESCRIPTION
## Purpose

To support pass-through management interface

This PR is chained to #465 

Fixes #466

## Details

Set the correct static IP in the management interface (port1) when pass-through without DHCP is configured.
This mode is selected as default as it provides an easier way to have the default route be used for the actual lab work. 

Additionally, update READMEs.

## Testing

In a lab with topology such as:

FGT -> Router -> Server

Where the router is the default route for both the FGT and the Server

TEST: ssh into FGT
EXPECTED:  FGT is reached. SSH connection completes
RESULT: As expected

TEST: ping Server from FGT
EXPECTED: Server is reached
RESULT: As expected

TEST: Ping FGT from server
EXPECTED: FGT is reached
RESULT: As expected