### PR TITLE
fortigate: fix bootstrap on FortiOS 7.6 and later

### DIFF
--- a/fortinet/fortigate/README.md
+++ b/fortinet/fortigate/README.md
@@ -36,6 +36,28 @@ keep working on 7.6 and later.
 * Fortigate 7.6.7 KVM
 * Fortigate 8.0.0 KVM
 
-These were all tested without a licence installed. An unlicensed FortiGate-VM
-boots, accepts configuration, and serves SSH and the GUI; it reports
-`License Status: Invalid` and FortiGuard-dependent features are unavailable.
+These were all tested without a licence installed, which is enough for the
+launcher itself: it bootstraps over the serial console, and CLI access over
+console and SSH works on an unlicensed unit.
+
+## Licensing
+
+An unlicensed FortiGate-VM reports `License Status: Invalid`. It boots and
+accepts configuration over the console and over SSH, but **the REST API does
+not work**. An API request with a valid `api-user` and token is rejected with
+HTTP 401, and FortiOS logs the reason as an internal error rather than an
+authentication or trusthost failure:
+
+```
+logdesc="Admin login failed" user="apitest" ui="https(...)" method="https"
+action="login" status="failed" reason="internal_error"
+```
+
+This matters for anything driving the device over HTTPS rather than SSH --
+netlab, for instance, configures FortiOS with the `fortinet.fortios` Ansible
+collection over `httpapi` on port 443. Installing a licence is reported to
+resolve it; Fortinet offers a free permanent trial licence that requires a
+FortiCare account, though that licence carries its own limits (1 vCPU, 2 GiB
+RAM, and a maximum of three interfaces, firewall policies and routes).
+
+FortiGuard-dependent features are unavailable in either case.

--- a/fortinet/fortigate/README.md
+++ b/fortinet/fortigate/README.md
@@ -15,6 +15,27 @@ If you need to run the image without using containerlab:
 
 `make docker-run-fortigate`
 
+## Credentials
+
+The launcher logs in with `--username` / `--password`, defaulting to
+`admin` / `admin`.
+
+FortiOS forces a password change on the first login, and from 7.6 it also
+ships a password policy enabled by default that requires at least 12
+characters including an upper case letter, a lower case letter, a digit and a
+non-alphanumeric character. A weak password such as the `admin` default cannot
+satisfy that, so the launcher completes the forced change with a compliant
+temporary password, disables the password policy, and then applies the
+requested password. Disabling the policy is what allows `admin` / `admin` to
+keep working on 7.6 and later.
+
 ## Tested versions
 
 * Fortigate 7.0.14 KVM
+* Fortigate 7.4.12 KVM
+* Fortigate 7.6.7 KVM
+* Fortigate 8.0.0 KVM
+
+These were all tested without a licence installed. An unlicensed FortiGate-VM
+boots, accepts configuration, and serves SSH and the GUI; it reports
+`License Status: Invalid` and FortiGuard-dependent features are unavailable.

--- a/fortinet/fortigate/docker/launch.py
+++ b/fortinet/fortigate/docker/launch.py
@@ -34,6 +34,13 @@ def trace(self, message, *args, **kws):
 
 logging.Logger.trace = trace
 
+# Temporary password used to satisfy the forced password change on first login.
+# FortiOS >= 7.6 enables a password policy by default that requires at least 12
+# characters with an upper case letter, a lower case letter, a digit and a
+# non-alphanumeric character. The policy is disabled and the requested password
+# applied immediately afterwards, so this value is never the final password.
+BOOTSTRAP_PASSWORD = "Vrnetlab1!Boot"
+
 
 class FortiOS_vm(vrnetlab.VM):
     def __init__(self, hostname, username, password, conn_mode):
@@ -58,6 +65,7 @@ class FortiOS_vm(vrnetlab.VM):
         self.qemu_args.extend(["-uuid", os.getenv("FORTIGATE_UUID") or str(uuid.uuid4())])
         self.spins = 0
         self.running = None
+        self.credentials_configured = False
 
         # set up the extra empty disk image
         # for fortigate logs
@@ -93,14 +101,26 @@ class FortiOS_vm(vrnetlab.VM):
                 self.logger.info("matched login prompt")
 
                 self.wait_write(self.username, wait=None)
-                self.wait_write("", wait=self.username)
-                self.wait_write(self.password, wait="Password")
-                self.wait_write(self.password, wait=None)
+                if self.credentials_configured:
+                    # Password already applied, so this is an ordinary login.
+                    self.wait_write(self.password, wait="Password")
+                else:
+                    # The account has no password yet and FortiOS forces a
+                    # change straight away. Since 7.6 a password policy is
+                    # enabled by default which rejects weak passwords such as
+                    # the "admin" default, so satisfy it with a temporary
+                    # password and apply the requested one afterwards.
+                    self.wait_write("", wait=self.username)
+                    self.wait_write(BOOTSTRAP_PASSWORD, wait="Password")
+                    self.wait_write(BOOTSTRAP_PASSWORD, wait=None)
 
             if ridx == 1:
                 # if we dont match the FortiGate-VM64-KVM # we assume we already have some configuration and
                 # may continue with configure the system to our needs.
                 self.logger.debug("ridx == 1")
+                if not self.credentials_configured:
+                    self._configure_credentials()
+                    return
                 self.wait_write("config system global", wait=None)
                 hostname_command = "set hostname " + self.hostname
                 self.wait_write(hostname_command, wait="global")
@@ -121,6 +141,39 @@ class FortiOS_vm(vrnetlab.VM):
                 self.spins = 0
 
         self.spins += 1
+
+    def _configure_credentials(self):
+        """Drop the default password policy and apply the requested password.
+
+        The forced password change at first login had to use
+        BOOTSTRAP_PASSWORD to get past the policy that FortiOS >= 7.6 enables
+        by default. Disabling that policy lets the requested password be
+        applied verbatim, which matters because consumers of this image expect
+        to log in with it.
+
+        Committing the change logs the console session out, so the caller must
+        go back through the login prompt afterwards.
+        """
+        self.logger.info("applying requested credentials")
+        self.wait_write("config system password-policy", wait=None)
+        self.wait_write("set status disable", wait="(password-policy)")
+        self.wait_write("end", wait="(password-policy)")
+        self.wait_write("config system admin", wait=None)
+        self.wait_write(f"edit {self.username}", wait="(admin)")
+        self.wait_write(f"set password {self.password}", wait="(admin)")
+        # Changing your own account's password prompts for the current one on
+        # some releases (8.0 does, 7.4 does not), so only answer it if asked.
+        # Either branch consumes the prompt that follows, so the next write
+        # must not wait for that same prompt again or it deadlocks.
+        (pw_idx, _, _) = self.tn.expect(
+            [b"current administrator password", rb"\(admin\) #"], timeout=10
+        )
+        if pw_idx == 0:
+            self.wait_write(BOOTSTRAP_PASSWORD, wait=None)
+            self.tn.expect([rb"\(admin\) #"], timeout=10)
+        self.wait_write("next", wait=None)
+        self.wait_write("end", wait="(admin)")
+        self.credentials_configured = True
 
     def _wait_reset(self):
         """


### PR DESCRIPTION
## Problem

The FortiGate launcher cannot bootstrap FortiOS 7.6 or later. It hangs, restarts the VM, and loops until it gives up.

`bootstrap_spin()` answers the forced password change at first login with the requested password, which defaults to `admin`. From 7.6 the VM images ship a password policy enabled by default:

```
You are forced to change your password. Please input a new password.
According to the password policy enforced on this device, please change your password!
New password must conform to the following policy:
minimum-length=12 minimum-upper-case-letter=1 minimum-lower-case-letter=1 minimum-number=1 minimum-non-alphanumeric=1

New Password:
New password doesn't conform to the password policy enforced on this device!
```

`admin` cannot satisfy that, so the change is rejected, the `#` prompt is never reached, and the launcher spins to 300 and restarts the VM.

I tested this against three releases, unlicensed:

| Version | Default password policy | Before this change |
| ------- | ----------------------- | ------------------ |
| 7.4.12  | not enforced            | works              |
| 7.6.7   | enforced                | never completes    |
| 8.0.0   | enforced                | never completes    |

7.4.12 prints no policy text at the prompt even though the same command exists, so the console wording is not a reliable indicator of whether a policy is active.

## Change

Complete the forced change with a policy-compliant temporary password, then disable the password policy and apply the requested password. Disabling the policy is what keeps `admin`/`admin` working, which is the documented default for this kind and what both containerlab and netlab expect.

Two details it has to account for, both found by testing:

- Committing the password change logs the console session out (`Auto backup config ... exit`), so the login branch has to handle a second, ordinary login afterwards. A `credentials_configured` flag distinguishes first login from subsequent ones.
- `set password` on your own account prompts for the current password on 8.0 but not on 7.4, so it is only answered when actually asked. Either branch consumes the prompt that follows, so the next write must not wait on that same prompt again or it deadlocks.

## Testing

Built and run with the patch on 7.4.12, 7.6.7 and 8.0.0. All three reach `Startup complete` and accept `admin`/`admin` over SSH:

```
7.4.12  Startup complete in 0:01:34   v7.4.12,build2902,260505 (GA.M)
7.6.7   Startup complete in 0:01:49   v7.6.7,build3704,260601 (GA.M)
8.0.0   Startup complete in 0:01:52   v8.0.0,build0167,260420 (GA.F)
```

7.4.12 is the regression case: it worked before this change and still does. I also confirmed the temporary password is not left valid afterwards.

I do not have a 7.0.14 image, so I could not re-test the version currently listed in the README. The path taken there is the same one 7.4.12 takes, and `config system password-policy` has been available well before 7.0, but a second pair of eyes on that would be welcome.

## Note on licensing

The containerlab docs for this kind state that 7.2.0 and later require a valid licence and internet connectivity. That does not match what I saw: all three versions above ran unlicensed, reporting `License Status: Invalid`, and accepted configuration over both the console and SSH. I suspect the password policy is what was actually being hit. Happy to raise that separately against the containerlab docs if that is useful.

## Open question

Disabling the password policy is a deliberate choice and I would rather you weighed in on it. The alternative is changing the default password to something compliant, but that breaks the documented `admin`/`admin` contract and every existing topology. Disabling the policy keeps the contract at the cost of relaxing a security default on what is a lab image. Happy to rework it if you would prefer a different approach.

## README

Added the versions tested here and a short section describing the credential handling, since the behaviour is otherwise surprising.
