### PR TITLE
IOL: README and Makefile for CML 2.10

### DIFF
--- a/cisco/iol/Makefile
+++ b/cisco/iol/Makefile
@@ -1,13 +1,55 @@
 VENDOR=Cisco
 NAME=IOL
 IMAGE_FORMAT=bin
-IMAGE_GLOB=*.bin
+IMAGE_GLOB=*.bin *.tar.gz
 DONT_COPY_COMMON=1
 
 # match versions like:
-# cisco_iol-17.12.01.bin
-# cisco_iol-L2-17.12.01.bin
-VERSION=$(shell echo $(IMAGE) | sed -e 's/cisco_iol-\(.*\)\.bin/\1/')
+# cisco_iol-17.12.01.bin      -> 17.12.01      loose binary (CML <= 2.9 refplat)
+# cisco_iol-L2-17.12.01.bin   -> L2-17.12.01
+# iol-xe-17-18-02.tar.gz      -> 17.18.02      container archive (CML >= 2.10)
+# ioll2-xe-17-18-02.tar.gz    -> L2-17.18.02
+VERSION=$(shell case '$(IMAGE)' in \
+	(ioll2-xe-*.tar.gz) echo '$(IMAGE)' | sed -e 's/^ioll2-xe-//' -e 's/\.tar\.gz$$//' -e 's/-/./g' -e 's/^/L2-/' ;; \
+	(iol-xe-*.tar.gz) echo '$(IMAGE)' | sed -e 's/^iol-xe-//' -e 's/\.tar\.gz$$//' -e 's/-/./g' ;; \
+	(*) echo '$(IMAGE)' | sed -e 's/cisco_iol-\(.*\)\.bin/\1/' ;; \
+	esac)
 
 -include ../../makefile-sanity.include
 -include ../../makefile.include
+
+# From CML 2.10 onwards IOL is shipped as an OCI/docker image archive instead of
+# a loose binary. The IOL ELF sits inside one of the layer blobs, so peel it out
+# on the fly rather than making the user hunt for it by hand.
+#
+# The archive is two tars deep:
+#
+#   iol-xe-17-18-02.tar.gz
+#   |-- manifest.json         names the config + layer blobs, layers bottom-first
+#   `-- blobs/sha256/
+#       |-- 483954...         config JSON
+#       |-- 9f410b...         layer 0, itself a tar: libc, iol-runner, .iourc
+#       `-- ac6972...         layer 1, itself a tar: ...plus the .iol binary
+#
+# So: read manifest.json for the blob paths, then probe each blob (stream it out
+# of the outer tar and list it with an inner tar) for a member ending in .iol.
+
+docker-build-image-copy:
+	@case '$(IMAGE)' in \
+	*.tar.gz) \
+		echo "--> $(IMAGE) is a container archive, extracting IOL binary"; \
+		blob=; member=; \
+		for b in $$(tar -xzOf '$(IMAGE)' manifest.json | grep -o 'blobs/sha256/[0-9a-f]\{64\}'); do \
+			m=$$(tar -xzOf '$(IMAGE)' "$$b" 2>/dev/null | tar -tvf - 2>/dev/null \
+				| awk '/^-.*\.iol$$/ { print $$NF }' | tail -1); \
+			if [ -n "$$m" ]; then blob=$$b; member=$$m; fi; \
+		done; \
+		if [ -z "$$member" ]; then \
+			echo "ERROR: no IOL binary (*.iol) found in any layer of $(IMAGE)"; exit 1; \
+		fi; \
+		echo "--> Found $$member in $$blob"; \
+		tar -xzOf '$(IMAGE)' "$$blob" | tar -xOf - "$$member" > docker/iol.bin; \
+		[ -s docker/iol.bin ] || { echo "ERROR: extracted IOL binary is empty"; exit 1; }; \
+		;; \
+	*) cp $(IMAGE)* docker/ ;; \
+	esac

--- a/cisco/iol/README.md
+++ b/cisco/iol/README.md
@@ -1,8 +1,8 @@
 # Cisco IOL (IOS on Linux)
 
-This is the containerlab/vrnetlab image for Cisco IOL (IOS On Linux).
+This is the containerlab/vrnetlab image for Cisco IOL (IOS On Linux). You can find the binary image as part of the CML image, with this [blog](https://marcstech.blog/archives/add-cisco-iol-containerlab-macos/) explaining the process.
 
-CML recently introduced IOL-XE which compared to other Cisco images, runs very lightly since it executes purely as a binary and has no requirement for a virtualisation layer.
+Compared to other Cisco images, IOL runs very lightly: it executes purely as a binary and needs no virtualisation layer.
 
 There are two types of IOL you can obtain:
 
@@ -11,32 +11,48 @@ There are two types of IOL you can obtain:
 
 ## Building the image
 
-Copy the `x86_64_crb_linux-adventerprisek9-ms` into this directory and rename it to `cisco_iol-x.y.z.bin` (x.y.z being the version number). For example `cisco_iol-17.12.01.bin`. The `.bin` extension is important.
+Copy your IOL image into this directory, named as below, then run `make` or `make docker-image`.
 
-> If using IOL-L2 it is recommended to name your image to identify it as IOL-L2. For example: `cisco_iol-L2-x.y.z.bin`
+| From                       | File                                  | Name it as                  | Tag           |
+| -------------------------- | ------------------------------------- | --------------------------- | ------------- |
+| CML 2.10+ (IOL)            | `iol-xe-17-18-02.tar.gz`              | keep as-is                  | `17.18.02`    |
+| CML 2.10+ (IOL-L2)         | `ioll2-xe-17-18-02.tar.gz`            | keep as-is                  | `L2-17.18.02` |
+| CML 2.9 and older (IOL)    | `x86_64_crb_linux-adventerprisek9-ms` | `cisco_iol-17.12.01.bin`    | `17.12.01`    |
+| CML 2.9 and older (IOL-L2) | `x86_64_crb_linux-adventerprisek9-ms` | `cisco_iol-L2-17.12.01.bin` | `L2-17.12.01` |
 
-> If you are getting the image from the CML refplat, the IOL image is under the `iol-xe-x.y.z` directory or `ioll2-xe-x.y.z` for IOL-L2.
+From CML 2.10 the refplat ships IOL as a container image archive; the build pulls the IOL binary
+out of it for you. Older refplats ship a loose binary under `iol-xe-x.y.z/` (or `ioll2-xe-x.y.z/`),
+which you must rename yourself — the `.bin` extension is what the build looks for.
 
-### Build command
+Check the result with `docker images`:
 
-Execute
-
+```sh
+REPOSITORY            TAG           IMAGE ID       CREATED          SIZE
+vrnetlab/cisco_iol    L2-17.12.01   c207d920446e   5 seconds ago    607MB
+vrnetlab/cisco_iol    17.12.01      30be6c875c80   12 minutes ago   704MB
 ```
-make docker-image
-```
 
-and the image will be built and tagged. You can view the image by executing `docker images`.
+### Extracting the binary by hand
 
-```
-containerlab@containerlab:~$ docker images
-REPOSITORY                      TAG           IMAGE ID       CREATED          SIZE
-vrnetlab/cisco_iol              L2-17.12.01   c207d920446e   5 seconds ago    607MB
-vrnetlab/cisco_iol              17.12.01      30be6c875c80   12 minutes ago   704MB
+Only needed if the automatic extraction breaks. The CML 2.10 archive is a container image archive;
+the IOL binary sits inside one of its layers.
+
+```sh
+# list the layers, in order
+tar -xzOf iol-xe-17-18-02.tar.gz manifest.json
+
+# list a layer's contents; the binary is a regular file ending in .iol
+# (binary.iol is only a symlink to it)
+tar -xzOf iol-xe-17-18-02.tar.gz blobs/sha256/<layer> | tar -tvf -
+
+# pull it out, without unpacking the rest of the archive
+tar -xzOf iol-xe-17-18-02.tar.gz blobs/sha256/<layer> \
+  | tar -xOf - x86_64_crb_linux-adventerprisek9-ms.iol > cisco_iol-17.18.02.bin
 ```
 
 ## Usage
 
-You can define the image easily and use it in a topology.
+Define the image in a topology. For IOL-L2, add `type: l2`.
 
 ```yaml
 # topology.clab.yaml
@@ -46,17 +62,5 @@ topology:
     iol:
       kind: cisco_iol
       image: vrnetlab/cisco_iol:<tag>
-```
-
-**IOL-L2**
-
-```yaml
-# topology.clab.yaml
-name: mylab
-topology:
-  nodes:
-    iol:
-      kind: cisco_iol
-      image: vrnetlab/cisco_iol:<tag>
-      type: l2
+      # type: l2  # only for IOL-L2
 ```


### PR DESCRIPTION
Updated the process to create the IOL images when using CML 2.10, as the binary file is a bit more hidden than with CML 2.9.
I've used this [comment](https://www.gns3.com/community/featured/how-to-import-iol-images-from-cml-2-10-since-the-files-are-changed) to create the extra steps in the Makefile if the file provided is a `tar.gz` instead of `.bin`