### PR TITLE
Fix regex for extracting XRd image reference

### DIFF
--- a/cisco/xrd-vrouter/docker/make-golden.sh
+++ b/cisco/xrd-vrouter/docker/make-golden.sh
@@ -29,7 +29,7 @@ marker="GOLDEN_PROVISIONED_OK"
 
 # Default the image reference to the tag recorded in the tarball.
 xrd_ref=${XRD_IMAGE_REF:-$(tar -xOf "$XRD_IMAGE_TAR" manifest.json \
-    | sed -E 's/.*"RepoTags":\["([^"]+)".*/\1/')}
+    | sed -E 's/.*"RepoTags":\s*\["([^"]+)".*/\1/')}
 [ -n "$xrd_ref" ] || { echo "ERROR: could not determine XRd image reference" >&2; exit 1; }
 echo "XRd image reference: $xrd_ref"
 


### PR DESCRIPTION
When viewing the manifest of the docker image there is a space between "RepoTags" and the content.
```
# tar -xOf xrd-vrouter-24.2.21.tar manifest.json
[{"Config": "a46b7bdbd48b939df97e5110f3fe988ba741963ae66f108504bf0242588c30c1.json", "RepoTags": ["ios-xr/xrd-vrouter:24.2.21"], "Layers": ["f1a01d831488237b2ba86cf0e8f538d9d9a6bebbab69ff4aaee90bad3c2e081a.tar"]}]
```

The sed output is the full line instead of just the file reference which results in an invalid yaml for cloud-init.
```
[    9.284341] cloud-init[721]: 2026-08-17 17:01:21,072 - util.py[WARNING]: Failed loading yaml blob. Invalid format at line 38 column 5: "while parsing a block mapping
[    9.286564] cloud-init[721]:   in "<unicode string>", line 38, column 5:
[    9.287650] cloud-init[721]:       - path: /etc/xrd/image
[    9.288566] cloud-init[721]:         ^
[    9.289245] cloud-init[721]: expected <block end>, but found '<scalar>'
[    9.290295] cloud-init[721]:   in "<unicode string>", line 39, column 18:
[    9.291359] cloud-init[721]:         content: "[{"Config": "a46b7bdbd48b939df97e51 ...
[    9.292590] cloud-init[721]:                      ^"
[    9.303094] cloud-init[721]: 2026-08-17 17:01:21,091 - util.py[WARNING]: Failed loading yaml blob. Invalid format at line 38 column 5: "while parsing a block mapping
[    9.305256] cloud-init[721]:   in "<unicode string>", line 38, column 5:
[    9.306310] cloud-init[721]:       - path: /etc/xrd/image
[    9.307186] cloud-init[721]:         ^
[    9.307835] cloud-init[721]: expected <block end>, but found '<scalar>'
[    9.308888] cloud-init[721]:   in "<unicode string>", line 39, column 18:
[    9.309914] cloud-init[721]:         content: "[{"Config": "a46b7bdbd48b939df97e51 ...
[    9.311096] cloud-init[721]:                      ^"
[    9.311914] cloud-init[721]: 2026-08-17 17:01:21,091 - cloud_config.py[WARNING]: Failed at merging in cloud config part from part-001: empty cloud config
```

This patch adds `\s*` to the regex to match any whitespace before the capture group