### PR TITLE
common: standardize QEMU resource overrides with QEMU_SMP/QEMU_MEMORY

### DIFF
--- a/cisco/cat9kv/README.md
+++ b/cisco/cat9kv/README.md
@@ -18,6 +18,7 @@ Eight interfaces will always appear regardless if you have defined any links in 
 Copy the Cat9kv or C9800-CL .qcow2 file in this directory and you can perform `make docker-image`. On average the image takes approxmiately ~4 minutes to build as an initial install process occurs.
 
 The build process automatically detects whether you're building a cat9kv or c9800cl image based on the filename:
+
 - Files containing "c9800" build as `cisco_c9800cl:VERSION`
 - Other files build as `cisco_cat9kv:VERSION`
 
@@ -32,9 +33,11 @@ To configure the Q200 image or enable a higher throughput dataplane for UADP; yo
 Known working versions:
 
 **Cat9kv:**
+
 - cat9kv-prd-17.12.01prd9.qcow2 (UADP & Q200)
 
 **C9800-CL:**
+
 - The C9800-CL uses the same IOS-XE base as Cat9kv and should work with versions 17.x and newer
 - Example filename: C9800-CL-universalk9.17.15.04b.qcow2
 
@@ -90,8 +93,8 @@ You can also use interface aliases of `GigabitEthernet1/0/x` or `Gi1/0/x`
 
 | Environment Variable  | Default       |
 | --------------------- | ------------- |
-| VCPU                  | 4             |
-| RAM                   | 18432         |
+| QEMU_SMP              | 4             |
+| QEMU_MEMORY           | 18432         |
 
 ### Example
 
@@ -103,8 +106,8 @@ topology:
       kind: cisco_cat9kv
       image: vrnetlab/vr-cat9kv:17.12.01
     env:
-        VCPU: 6
-        RAM: 12288
+        QEMU_SMP: 6
+        QEMU_MEMORY: 12288
 ```
 
 ## System requirements

--- a/cisco/xrd-vrouter/README.md
+++ b/cisco/xrd-vrouter/README.md
@@ -26,13 +26,13 @@ Per running node, XRd vRouter needs:
 - **RAM** — ~5 GiB minimum; the launcher defaults to **10 GiB**, with a hard floor of **8 GiB**.
 - **Hugepages** — 3 GiB of 1 GiB hugepages.
 
-Tune vCPU/RAM with the `VCPU` / `RAM` node env. The 10 GiB default is comfortable; drop toward the 8 GiB floor only to fit more nodes on a host — at 8 GiB an idle node booted and forwarded with ~800 MB to spare, which leaves little headroom for feature-heavy configs.
+Tune vCPU/RAM with the `QEMU_SMP` / `QEMU_MEMORY` node env. The 10 GiB default is comfortable; drop toward the 8 GiB floor only to fit more nodes on a host — at 8 GiB an idle node booted and forwarded with ~800 MB to spare, which leaves little headroom for feature-heavy configs.
 
 Unlike the control-plane `cisco_xrd`, the elevated inotify limits XR needs are tuned inside the micro-VM, so no host inotify tuning is required.
 
 ## Usage with containerlab
 
-Use the dedicated [`cisco_xrd_vrouter`](https://containerlab.srlinux.dev/manual/kinds/cisco_xrd_vrouter/) kind — it ships XRd vRouter's tuned defaults (4 vCPU / 10 GiB). The stock [`cisco_xrv9k`](https://containerlab.srlinux.dev/manual/kinds/vr-xrv9k/) kind is **also** compatible (XRd vRouter is IOS XR), but it defaults to XRv9k's heavier 2 vCPU / 16 GiB, so set `RAM` explicitly there.
+Use the dedicated [`cisco_xrd_vrouter`](https://containerlab.srlinux.dev/manual/kinds/cisco_xrd_vrouter/) kind — it ships XRd vRouter's tuned defaults (4 vCPU / 10 GiB). The stock [`cisco_xrv9k`](https://containerlab.srlinux.dev/manual/kinds/vr-xrv9k/) kind is **also** compatible (XRd vRouter is IOS XR), but it defaults to XRv9k's heavier 2 vCPU / 16 GiB, so set `QEMU_MEMORY` explicitly there.
 
 ```yaml
 name: xrd

--- a/common/test_vrnetlab.py
+++ b/common/test_vrnetlab.py
@@ -1,0 +1,84 @@
+import ast
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent))
+import vrnetlab
+
+
+class TestQemuResourceEnvironment(unittest.TestCase):
+    def setUp(self):
+        self.vm = object.__new__(vrnetlab.VM)
+        self.vm._ram = 4096
+        self.vm._cpu = "host"
+        self.vm._smp = "1"
+
+    def test_defaults(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(self.vm.ram, 4096)
+            self.assertEqual(self.vm.cpu, "host")
+            self.assertEqual(self.vm.smp, "1")
+
+    def test_environment_overrides_defaults(self):
+        with patch.dict(
+            os.environ,
+            {
+                "QEMU_MEMORY": "8192",
+                "QEMU_CPU": "qemu64",
+                "QEMU_SMP": "4",
+            },
+            clear=False,
+        ):
+            self.assertEqual(self.vm.ram, 8192)
+            self.assertEqual(self.vm.cpu, "qemu64")
+            self.assertEqual(self.vm.smp, "4")
+
+    def test_sonic_launchers_use_common_smp_override(self):
+        launchers = [
+            Path(__file__).parents[1] / "sonic/docker/launch.py",
+            Path(__file__).parents[1] / "dell/dell_sonic/docker/launch.py",
+            Path(__file__).parents[1] / "plvision/plvision_sonic/docker/launch.py",
+        ]
+
+        for launcher in launchers:
+            source = launcher.read_text()
+            self.assertNotIn('self.qemu_args.extend(["-smp", "2"])', source)
+            tree = ast.parse(source, filename=str(launcher))
+            smp_defaults = [
+                keyword.value.value
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Call)
+                for keyword in node.keywords
+                if keyword.arg == "smp"
+                and isinstance(keyword.value, ast.Constant)
+                and isinstance(keyword.value.value, str)
+            ]
+            self.assertIn("2", smp_defaults, launcher)
+
+    def test_sros_uses_common_resource_properties(self):
+        launcher = Path(__file__).parents[1] / "nokia/sros/docker/launch.py"
+        tree = ast.parse(launcher.read_text(), filename=str(launcher))
+        sros_vm = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "SROS_vm"
+        )
+        property_names = {
+            node.name
+            for node in sros_vm.body
+            if isinstance(node, ast.FunctionDef)
+            and any(
+                isinstance(decorator, ast.Name) and decorator.id == "property"
+                for decorator in node.decorator_list
+            )
+        }
+        self.assertNotIn("ram", property_names)
+        self.assertNotIn("cpu", property_names)
+        self.assertNotIn("smp", property_names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dell/dell_sonic/docker/launch.py
+++ b/dell/dell_sonic/docker/launch.py
@@ -48,9 +48,8 @@ class Dell_Sonic_VM(vrnetlab.VM):
                 disk_image = "/" + e
                 break
         super(Dell_Sonic_VM, self).__init__(
-            username, password, disk_image=disk_image, ram=4096
+            username, password, disk_image=disk_image, ram=4096, smp="2"
         )
-        self.qemu_args.extend(["-smp", "2"])
         self.nic_type = "virtio-net-pci"
         self.conn_mode = conn_mode
         self.num_nics = 10

--- a/nokia/sros/docker/launch.py
+++ b/nokia/sros/docker/launch.py
@@ -1343,23 +1343,6 @@ class SROS_vm(vrnetlab.VM):
         # close scrapli device driver
         self.sros_con.close()
 
-    @property
-    def ram(self):
-        """Ignore environment variables here, since getMem function is used"""
-        return self._ram
-
-    @property
-    def cpu(self):
-        """Ignore environment variables here, since CPU environment variable is used for number of cpus in getCPU function"""
-
-        return str(self._cpu)
-
-    @property
-    def smp(self):
-        """Ignore environment variables here, since CPU environment variable is used for number of cpus in getCPU function"""
-
-        return str(self._smp)
-
 
 class SROS_integrated(SROS_vm):
     """Integrated VSR-SIM"""

--- a/plvision/plvision_sonic/docker/launch.py
+++ b/plvision/plvision_sonic/docker/launch.py
@@ -48,9 +48,8 @@ class PLVision_SONiC_VM(vrnetlab.VM):
                 disk_image = "/" + e
                 break
         super(PLVision_SONiC_VM, self).__init__(
-            username, password, disk_image=disk_image, ram=4096
+            username, password, disk_image=disk_image, ram=4096, smp="2"
         )
-        self.qemu_args.extend(["-smp", "2"])
         self.nic_type = "virtio-net-pci"
         self.conn_mode = conn_mode
         self.num_nics = 96
@@ -106,27 +105,25 @@ class PLVision_SONiC_VM(vrnetlab.VM):
         # Set IPv4 Management Address if present:
         if self.mgmt_address_ipv4 and "." in self.mgmt_address_ipv4:
             self.wait_write(
-               f"/usr/sbin/ip address add {self.mgmt_address_ipv4} dev eth0",
-               "#"
-           )
+                f"/usr/sbin/ip address add {self.mgmt_address_ipv4} dev eth0", "#"
+            )
         # Note: IPv6 has not been fully tested - it has reported problems under Enterprise SONiC
         # Set IPv6 Management Address if present:
         if self.mgmt_address_ipv6 and ":" in self.mgmt_address_ipv6:
             self.wait_write(
-                f"/usr/sbin/ip -6 address add {self.mgmt_address_ipv6} dev eth0",
-                "#"
+                f"/usr/sbin/ip -6 address add {self.mgmt_address_ipv6} dev eth0", "#"
             )
         # Set IPv4 Management Gateway if present:
         if self.mgmt_gw_ipv4 and "." in self.mgmt_gw_ipv4:
             self.wait_write(
-                f"while ! /usr/sbin/ip link show eth0 | grep -q \"state UP\"; do sleep 1; done; /usr/sbin/ip route add default via {self.mgmt_gw_ipv4} dev eth0",
-                "#"
+                f'while ! /usr/sbin/ip link show eth0 | grep -q "state UP"; do sleep 1; done; /usr/sbin/ip route add default via {self.mgmt_gw_ipv4} dev eth0',
+                "#",
             )
         # Set IPv6 Management Gateway if present:
         if self.mgmt_gw_ipv6 and ":" in self.mgmt_gw_ipv6:
             self.wait_write(
-                f"while ! /usr/sbin/ip link show eth0 | grep -q \"state UP\"; do sleep 1; done;/usr/sbin/ip -6 route add default via {self.mgmt_gw_ipv6} dev eth0",
-                "#"
+                f'while ! /usr/sbin/ip link show eth0 | grep -q "state UP"; do sleep 1; done;/usr/sbin/ip -6 route add default via {self.mgmt_gw_ipv6} dev eth0',
+                "#",
             )
         self.wait_write("passwd -q %s" % (self.username))
         self.wait_write(self.password, "New password:")

--- a/sonic/docker/launch.py
+++ b/sonic/docker/launch.py
@@ -48,9 +48,8 @@ class SONiC_vm(vrnetlab.VM):
                 disk_image = "/" + e
                 break
         super(SONiC_vm, self).__init__(
-            username, password, disk_image=disk_image, ram=4096
+            username, password, disk_image=disk_image, ram=4096, smp="2"
         )
-        self.qemu_args.extend(["-smp", "2"])
         self.nic_type = "virtio-net-pci"
         self.conn_mode = conn_mode
         self.num_nics = 96
@@ -106,27 +105,25 @@ class SONiC_vm(vrnetlab.VM):
         # Set IPv4 Management Address if present:
         if self.mgmt_address_ipv4 and "." in self.mgmt_address_ipv4:
             self.wait_write(
-               f"/usr/sbin/ip address add {self.mgmt_address_ipv4} dev eth0",
-               "#"
-           )
+                f"/usr/sbin/ip address add {self.mgmt_address_ipv4} dev eth0", "#"
+            )
         # Note: IPv6 has not been fully tested - it has reported problems under Enterprise SONiC
         # Set IPv6 Management Address if present:
         if self.mgmt_address_ipv6 and ":" in self.mgmt_address_ipv6:
             self.wait_write(
-                f"/usr/sbin/ip -6 address add {self.mgmt_address_ipv6} dev eth0",
-                "#"
+                f"/usr/sbin/ip -6 address add {self.mgmt_address_ipv6} dev eth0", "#"
             )
         # Set IPv4 Management Gateway if present:
         if self.mgmt_gw_ipv4 and "." in self.mgmt_gw_ipv4:
             self.wait_write(
-                f"while ! /usr/sbin/ip link show eth0 | grep -q \"state UP\"; do sleep 1; done; /usr/sbin/ip route add default via {self.mgmt_gw_ipv4} dev eth0",
-                "#"
+                f'while ! /usr/sbin/ip link show eth0 | grep -q "state UP"; do sleep 1; done; /usr/sbin/ip route add default via {self.mgmt_gw_ipv4} dev eth0',
+                "#",
             )
         # Set IPv6 Management Gateway if present:
         if self.mgmt_gw_ipv6 and ":" in self.mgmt_gw_ipv6:
             self.wait_write(
-                f"while ! /usr/sbin/ip link show eth0 | grep -q \"state UP\"; do sleep 1; done;/usr/sbin/ip -6 route add default via {self.mgmt_gw_ipv6} dev eth0",
-                "#"
+                f'while ! /usr/sbin/ip link show eth0 | grep -q "state UP"; do sleep 1; done;/usr/sbin/ip -6 route add default via {self.mgmt_gw_ipv6} dev eth0',
+                "#",
             )
         self.wait_write("passwd -q %s" % (self.username))
         self.wait_write(self.password, "New password:")


### PR DESCRIPTION
Make all VM launchers use the base VM class ram/cpu/smp properties, which read QEMU_* environment variables. SONiC variants pass smp via super().__init__() instead of extending qemu_args; SROS drops its property overrides. Update Cisco READMEs to the new variable names and add unit tests to enforce the common behavior.